### PR TITLE
Resolve path to dinov2

### DIFF
--- a/promptda/promptda.py
+++ b/promptda/promptda.py
@@ -22,8 +22,10 @@ class PromptDA(nn.Module):
 
         self.encoder = encoder
         self.model_config = model_config
+        module_path = Path(__file__) # From anywhere else: module_path = Path(inspect.getfile(PromptDA))
+        package_base_dir = str(Path(*module_path.parts[:-2])) # extract path to PromptDA module, then resolve to repo base dir for dinov2 load
         self.pretrained = torch.hub.load(
-            'torchhub/facebookresearch_dinov2_main',
+            f'{package_base_dir}/torchhub/facebookresearch_dinov2_main',
             'dinov2_{:}14'.format(encoder),
             source='local',
             pretrained=False)


### PR DESCRIPTION
Hello,

thanks for the great work on the PromptDA paper and models!

I have just tried out the repository according to the installation and usage instructions. Unfortunately, the path to the local torchhub folder does not properly resolve for me, resulting in `FileNotFoundError: [Errno 2] No such file or directory: '/torchhub/facebookresearch_dinov2_main/hubconf.py'`. 

I have created a quick fix that resolves the path relative to the `promptda.py` file. I have only tested it on my setup (Ubuntu 22.04 within `nvidia/cuda:11.8.0-devel-ubuntu22.04` Docker Container with Python 3.10.12). Therefore, before a merge, this probably needs to be tested on other setups. Maybe this helps someone with similar problems out.